### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -44,7 +44,7 @@ getSimplePairData	KEYWORD2
 setEspNowKey	KEYWORD2
 getEspNowKey	KEYWORD2
 setPassword16Byte	KEYWORD2
-getPassword16Byte	KEYWORD2s
+getPassword16Byte	KEYWORD2
 getSourceMacAddress	KEYWORD2
 getSourceMacAddress	KEYWORD2
 getDestinationMacAddress	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -64,7 +64,7 @@ getVersion	KEYWORD2
 #	Constants	(LITERAL1)
 #######################################
 
-SP_OFF		LITERAL1
+SP_OFF	LITERAL1
 SP_STA	LITERAL1
 SP_AP	LITERAL1
 


### PR DESCRIPTION
- Correct invalid keywords.txt KEYWORD_TOKENTYPE.
- Use a single tab field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords